### PR TITLE
Add dropdown menu for onboarding restart

### DIFF
--- a/app/components/AppHeader.jsx
+++ b/app/components/AppHeader.jsx
@@ -62,8 +62,6 @@ const AppHeader = () => {
 
   const handleRestartOnboarding = () => {
     handleAiProviderMenuClose();
-    // Remove the local storage flag
-    localStorage.removeItem('onboardingCompleted');
     // Open the onboarding wizard
     setOnboardingOpen(true);
   };

--- a/app/components/AppHeader.jsx
+++ b/app/components/AppHeader.jsx
@@ -3,6 +3,7 @@ import ComputerIcon from '@mui/icons-material/Computer';
 import KeyIcon from '@mui/icons-material/Key';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import PsychologyIcon from '@mui/icons-material/Psychology';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import WorkIcon from '@mui/icons-material/Work';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
@@ -18,13 +19,16 @@ import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useAiProvider } from '../contexts/AiProviderContext';
 import { useApiKey } from '../contexts/ApiKeyContext';
 import ApiKeyDialog from './ApiKeyDialog';
+import OnboardingWizard from './OnboardingWizard';
 
 const AppHeader = () => {
   const location = useLocation();
   const { apiKey, clearApiKey, isApiKeyValid } = useApiKey();
   const { hasConfiguredProvider, isProviderValid } = useAiProvider();
   const [anchorEl, setAnchorEl] = useState(null);
+  const [aiProviderAnchorEl, setAiProviderAnchorEl] = useState(null);
   const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false);
+  const [onboardingOpen, setOnboardingOpen] = useState(false);
 
   const isActive = path => {
     return location.pathname === path;
@@ -46,6 +50,27 @@ const AppHeader = () => {
   const handleClearApiKey = () => {
     clearApiKey();
     handleMenuClose();
+  };
+
+  const handleAiProviderMenuClick = event => {
+    setAiProviderAnchorEl(event.currentTarget);
+  };
+
+  const handleAiProviderMenuClose = () => {
+    setAiProviderAnchorEl(null);
+  };
+
+  const handleRestartOnboarding = () => {
+    handleAiProviderMenuClose();
+    // Remove the local storage flag
+    localStorage.removeItem('onboardingCompleted');
+    // Open the onboarding wizard
+    setOnboardingOpen(true);
+  };
+
+  const handleOnboardingComplete = () => {
+    localStorage.setItem('onboardingCompleted', 'true');
+    setOnboardingOpen(false);
   };
 
   const aiProviderStatus = hasConfiguredProvider
@@ -118,7 +143,12 @@ const AppHeader = () => {
           </Box>
 
           <Tooltip title={`AI Provider: ${aiProviderStatusText}`}>
-            <IconButton color={aiProviderStatus} size="large" sx={{ mr: 1 }}>
+            <IconButton
+              color={aiProviderStatus}
+              size="large"
+              sx={{ mr: 1 }}
+              onClick={handleAiProviderMenuClick}
+            >
               <PsychologyIcon />
             </IconButton>
           </Tooltip>
@@ -139,10 +169,26 @@ const AppHeader = () => {
             </MenuItem>
             {apiKey && <MenuItem onClick={handleClearApiKey}>Clear API Key</MenuItem>}
           </Menu>
+
+          <Menu
+            anchorEl={aiProviderAnchorEl}
+            open={Boolean(aiProviderAnchorEl)}
+            onClose={handleAiProviderMenuClose}
+          >
+            <MenuItem onClick={handleRestartOnboarding}>
+              <RestartAltIcon sx={{ mr: 1 }} />
+              Restart Onboarding
+            </MenuItem>
+          </Menu>
         </Toolbar>
       </AppBar>
 
       <ApiKeyDialog open={apiKeyDialogOpen} onClose={() => setApiKeyDialogOpen(false)} />
+      <OnboardingWizard
+        open={onboardingOpen}
+        onClose={() => setOnboardingOpen(false)}
+        onComplete={handleOnboardingComplete}
+      />
     </>
   );
 };


### PR DESCRIPTION
Add a dropdown menu to the AI provider icon in the app header to enable restarting the onboarding wizard.