### PR TITLE
Remove default props and add type definitions

### DIFF
--- a/app/components/ResolutionRecommendation.tsx
+++ b/app/components/ResolutionRecommendation.tsx
@@ -2,7 +2,13 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import PropTypes from 'prop-types';
+
+interface ResolutionRecommendationProps {
+  width: number;
+  height: number;
+  onRecommendedResolutionClick: (resolution: { width: number; height: number }) => void;
+  disabled?: boolean;
+}
 
 const recommendedResolutions = [
   {
@@ -15,7 +21,12 @@ const recommendedResolutions = [
   },
 ];
 
-const ResolutionRecommendation = ({ width, height, onRecommendedResolutionClick, disabled }) => {
+const ResolutionRecommendation = ({ 
+  width, 
+  height, 
+  onRecommendedResolutionClick, 
+  disabled = false 
+}: ResolutionRecommendationProps) => {
   const isRecommendedResolution = recommendedResolutions.some(
     resolution => resolution.width === width && resolution.height === height,
   );
@@ -55,17 +66,6 @@ const ResolutionRecommendation = ({ width, height, onRecommendedResolutionClick,
       </Box>
     </Alert>
   );
-};
-
-ResolutionRecommendation.propTypes = {
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-  onRecommendedResolutionClick: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
-};
-
-ResolutionRecommendation.defaultProps = {
-  disabled: false,
 };
 
 export default ResolutionRecommendation;

--- a/app/components/ResolutionRecommendation.tsx
+++ b/app/components/ResolutionRecommendation.tsx
@@ -21,11 +21,11 @@ const recommendedResolutions = [
   },
 ];
 
-const ResolutionRecommendation = ({ 
-  width, 
-  height, 
-  onRecommendedResolutionClick, 
-  disabled = false 
+const ResolutionRecommendation = ({
+  width,
+  height,
+  onRecommendedResolutionClick,
+  disabled = false,
 }: ResolutionRecommendationProps) => {
   const isRecommendedResolution = recommendedResolutions.some(
     resolution => resolution.width === width && resolution.height === height,


### PR DESCRIPTION
Remove React `defaultProps` and `PropTypes` from `ResolutionRecommendation` component and convert to minimal TypeScript type definitions using default parameter values.

---
<a href="https://cursor.com/background-agent?bcId=bc-63ff63e3-2a4b-4a18-b590-b15388ff7abd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63ff63e3-2a4b-4a18-b590-b15388ff7abd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>