### PR TITLE
add AES-256-CBC openvpn cipher

### DIFF
--- a/infra/docker/legacy-use-target/image/start_vpn.sh
+++ b/infra/docker/legacy-use-target/image/start_vpn.sh
@@ -153,7 +153,7 @@ EOF
         --auth-user-pass "$AUTH_FILE" \
         --verb 4 \
         --log "$OPENVPN_LOG" \
-        --data-ciphers "AES-256-GCM:AES-128-GCM:AES-128-CBC:CHACHA20-POLY1305" \
+        --data-ciphers "AES-256-GCM:AES-128-GCM:AES-256-CBC:AES-128-CBC:CHACHA20-POLY1305" \
         --cipher AES-128-CBC \
         --dev tun0 \
         --script-security 2 \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VPN cipher configuration to include AES-256-CBC alongside existing GCM and CBC options, expanding compatibility with a wider range of OpenVPN servers.
  * Enhances interoperability and adds a fallback for environments lacking GCM support; may improve connection success in legacy setups.
  * No action required; existing configurations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->