### PR TITLE
Archive sessions where the container is not running

### DIFF
--- a/server/utils/session_monitor.py
+++ b/server/utils/session_monitor.py
@@ -113,7 +113,12 @@ async def monitor_sessions_for_tenant(tenant_schema: str):
                         f"Container for session {session_id} is not running, updating state to 'destroyed'"
                     )
                     db_service.update_session(
-                        session_id, {'state': 'destroyed', 'is_archived': True}
+                        session_id,
+                        {
+                            'state': 'destroyed',
+                            'is_archived': True,
+                            'archive_reason': 'container-not-running',
+                        },
                     )
                     continue
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents crashes when containers are missing or stop mid-check; status now degrades gracefully.
  - Health and load metrics are only collected and shown when containers are running, avoiding misleading data.
  - IP or metric retrieval failures no longer block status updates; errors are logged and reflected in status.

- Refactor
  - Streamlined container status reporting for improved stability and clarity.
  - Session updates now include an archive_reason (“container-not-running”) for clearer lifecycle tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->