### PR TITLE
Fix /api proxy in vite to not forward /apis calls

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -26,7 +26,7 @@ export default defineConfig({
       ignored: ['**/.venv/**', '**/.git/**', '**/server/**', '**/node_modules/**'],
     },
     proxy: {
-      '/api': {
+      '/api/': {
         target: `http://${process.env.VITE_PROXY_TARGET || 'localhost'}:8088`,
         ws: true,
         configure: (proxy, _options) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved API request routing by refining the proxy path to match only /api/ paths, preventing unintended captures (e.g., /apiv2) and reducing sporadic request failures.

- Chores
  - Adjusted development proxy configuration for more predictable behavior and compatibility with environments expecting a trailing slash on API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->