### PR TITLE
feat: toggle advanced API fields

### DIFF
--- a/app/components/ApiRecoveryPrompt.tsx
+++ b/app/components/ApiRecoveryPrompt.tsx
@@ -1,0 +1,57 @@
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { getApiDefinitionDetails, updateApiDefinition } from '../services/apiService';
+
+interface ApiRecoveryPromptProps {
+  apiName: string;
+  isArchived: boolean;
+}
+
+const ApiRecoveryPrompt = ({ apiName, isArchived }: ApiRecoveryPromptProps) => {
+  const [recoveryPrompt, setRecoveryPrompt] = useState('');
+
+  useEffect(() => {
+    const loadPrompt = async () => {
+      try {
+        const data: any = await getApiDefinitionDetails(apiName);
+        setRecoveryPrompt(data?.recovery_prompt || '');
+      } catch (err) {
+        console.error('Error loading recovery prompt:', err);
+      }
+    };
+    loadPrompt();
+  }, [apiName]);
+
+  const handleSave = async () => {
+    try {
+      await updateApiDefinition(apiName, { recovery_prompt: recoveryPrompt } as any);
+    } catch (err) {
+      console.error('Error saving recovery prompt:', err);
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Recovery Prompt
+      </Typography>
+      <TextField
+        label="Recovery Prompt"
+        fullWidth
+        multiline
+        rows={6}
+        value={recoveryPrompt}
+        onChange={e => setRecoveryPrompt(e.target.value)}
+        margin="normal"
+        disabled={isArchived}
+      />
+      {!isArchived && (
+        <Button variant="outlined" sx={{ mt: 2 }} onClick={handleSave}>
+          Save Recovery Prompt
+        </Button>
+      )}
+    </Box>
+  );
+};
+
+export default ApiRecoveryPrompt;

--- a/app/components/EditApiDefinition.tsx
+++ b/app/components/EditApiDefinition.tsx
@@ -28,6 +28,7 @@ import {
   updateApiDefinition,
 } from '../services/apiService';
 import ApiCustomActions from './ApiCustomActions';
+import ApiRecoveryPrompt from './ApiRecoveryPrompt';
 
 // Local types for editor state (permissive to keep edits minimal)
 interface ApiParamState {
@@ -80,6 +81,7 @@ const EditApiDefinition = () => {
   const [snackbarSeverity, setSnackbarSeverity] = useState<
     'success' | 'error' | 'warning' | 'info'
   >('success');
+  const [showAdvancedFields, setShowAdvancedFields] = useState<boolean>(false);
 
   // Load API definition details
   useEffect(() => {
@@ -628,10 +630,31 @@ const EditApiDefinition = () => {
           </Button>
         )}
       </Paper>
-      {/* Custom Actions */}
-      <Paper sx={{ p: 3, mb: 3 }}>
-        <ApiCustomActions apiName={apiName as string} isArchived={apiDefinition.is_archived} />
-      </Paper>
+      {!apiDefinition.is_archived && (
+        <Button
+          size="small"
+          onClick={() => setShowAdvancedFields(prev => !prev)}
+          sx={{ mb: 2 }}
+        >
+          {showAdvancedFields ? 'Hide advanced' : 'Show advanced'}
+        </Button>
+      )}
+      {showAdvancedFields && (
+        <>
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <ApiCustomActions
+              apiName={apiName as string}
+              isArchived={apiDefinition.is_archived}
+            />
+          </Paper>
+          <Paper sx={{ p: 3, mb: 3 }}>
+            <ApiRecoveryPrompt
+              apiName={apiName as string}
+              isArchived={apiDefinition.is_archived}
+            />
+          </Paper>
+        </>
+      )}
       <Paper sx={{ p: 3, mb: 3 }}>
         <Typography variant="h6" gutterBottom>
           Prompt Configuration


### PR DESCRIPTION
## Summary
- toggle advanced API options in editor with a small button
- group custom actions and recovery prompt under advanced section
- add basic ApiRecoveryPrompt component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: starts Vite dev server, no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68b84cb7b5e0832b84000a485c9259b3