### PR TITLE
Enhanced Docker functionality in development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ server-tests:
 # Docker Compose Commands
 docker-dev: ensure-env
 	@echo "🚀 Starting legacy-use in DEVELOPMENT mode with hot-reloading..."
-	docker-compose -f docker-compose.yml -f docker-compose.dev-override.yml up
+	docker compose -f docker-compose.yml -f docker-compose.dev-override.yml up $(if $(DETACHED),-d,) $(if $(BUILD),--build,)
+
+docker-dev-down:
+	@echo "🛑 Stopping legacy-use in DEVELOPMENT mode..."
+	docker compose -f docker-compose.yml -f docker-compose.dev-override.yml down $(if $(CLEAN),--remove-orphans -v,)
 
 docker-prod: ensure-env
 	@echo "🚀 Starting legacy-use in PRODUCTION mode..."
@@ -37,7 +41,7 @@ docker-prod: ensure-env
 		export DATABASE_URL=$$(aws secretsmanager get-secret-value --secret-id $$SECRET_NAME --query SecretString --output text); \
 	fi
 	@echo "🔧 Starting services in production mode..."
-	docker-compose up -d
+	docker compose up -d
 
 # Individual Docker Build Targets
 docker-build-target:

--- a/docker-compose.dev-override.yml
+++ b/docker-compose.dev-override.yml
@@ -17,3 +17,31 @@ services:
       - ./vite.config.js:/web/vite.config.js
       - ./orval.config.ts:/web/orval.config.ts
       - ./index.html:/web/index.html
+
+  # GnuCash App
+  legacy-use-linux-machine:
+    build:
+      context: .
+      dockerfile: infra/docker/linux-machine/Dockerfile
+    image: legacy-use-core-linux-machine:local
+    container_name: legacy-use-linux-machine
+    environment:
+      - VNC_PASSWORD=password123
+      - USER=developer
+      - PASSWORD=developer123
+      - RESOLUTION=1024x768
+    volumes:
+      - linux-home:/home/developer
+      - linux-workspace:/workspace
+      - /dev/shm:/dev/shm
+    working_dir: /workspace
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost/ || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  linux-home:
+  linux-workspace:


### PR DESCRIPTION
- Updated docker command syntax from `docker-compose` to `docker compose` for consistency
- Added support for optional flags in `docker-dev` command:
  - `DETACHED` flag to run in detached mode
  - `BUILD` flag to rebuild containers
- Added new `docker-dev-down` command with `CLEAN` option for thorough cleanup
- Added gnucache docker container for env environment

i added the gnucach container that was started separately before with the makefile into the dev overrides so it is easier to start a fully dev environment with a running app 