### PR TITLE
Feat/make schema endpoint

### DIFF
--- a/server/models/base.py
+++ b/server/models/base.py
@@ -128,7 +128,7 @@ class MakeResponseSchema(BaseModel):
     name: str
     type: str
     label: str
-    spec: Optional[List['MakeResponseSchema'] | 'MakeResponseSchema']
+    spec: Optional[List['MakeResponseSchema'] | 'MakeResponseSchema'] = None
 
 
 class TargetType(str, Enum):

--- a/server/models/base.py
+++ b/server/models/base.py
@@ -119,6 +119,18 @@ IMPORTANT INSTRUCTIONS FOR RETURNING RESULTS:
         return prompt_text
 
 
+class APIDefinitionWithSchema(APIDefinition):
+    response_schema: dict[str, Any]
+
+
+# https://developers.make.com/custom-apps-documentation/app-blocks/interface
+class MakeResponseSchema(BaseModel):
+    name: str
+    type: str
+    label: str
+    spec: Optional[List['MakeResponseSchema'] | 'MakeResponseSchema']
+
+
 class TargetType(str, Enum):
     RDP = 'rdp'
     VNC = 'vnc'

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -105,7 +105,7 @@ async def get_api_definition(
 
 @api_router.get(
     '/definitions/{api_name}/make_schema',
-    response_model=MakeResponseSchema,
+    response_model=List[MakeResponseSchema],
     tags=['API Definitions'],
 )
 async def make_schema(
@@ -113,9 +113,7 @@ async def make_schema(
 ):
     """Return response schema in make.com compatible format."""
     api = await db_tenant.get_api_definition_by_name(api_name)
-    response_schema = await get_api_response_schema_by_version_id(
-        api.version_id, db_tenant
-    )
+    response_schema = await get_api_response_schema(api.id, db_tenant)
     make_schema = openapi_to_make_schema(response_schema)
     return make_schema
 

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -113,6 +113,10 @@ async def make_schema(
 ):
     """Return response schema in make.com compatible format."""
     api = await db_tenant.get_api_definition_by_name(api_name)
+    if not api:
+        raise HTTPException(
+            status_code=404, detail=f"API definition '{api_name}' not found"
+        )
     response_schema = await get_api_response_schema(api.id, db_tenant)
     make_schema = openapi_to_make_schema(response_schema)
     return make_schema

--- a/server/utils/api_definitions.py
+++ b/server/utils/api_definitions.py
@@ -73,6 +73,8 @@ def openapi_to_make_schema(openapi_schema: dict[str, Any]) -> List[MakeResponseS
     def get_make_type(type: str) -> str:
         if type == 'integer':
             return 'number'
+        elif type == 'number':
+            return 'number'
         elif type == 'boolean':
             return 'boolean'
         elif type == 'array':

--- a/server/utils/api_definitions.py
+++ b/server/utils/api_definitions.py
@@ -87,9 +87,6 @@ def openapi_to_make_schema(openapi_schema: dict[str, Any]) -> List[MakeResponseS
     def first_schema_option(schema: dict[str, Any]) -> dict[str, Any]:
         """Return the first schema entry when union keywords like anyOf are present."""
 
-        if not isinstance(schema, dict):
-            return {}
-
         any_of = schema.get('anyOf')
         if isinstance(any_of, list) and any_of:
             first = any_of[0]
@@ -103,18 +100,10 @@ def openapi_to_make_schema(openapi_schema: dict[str, Any]) -> List[MakeResponseS
     for key, value in openapi_schema.get('properties', {}).items():
         if value.get('type') == 'array':
             raw_items = value.get('items')
+            # handle anyOf -> 'items': { 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}
             items_schema = first_schema_option(
                 raw_items if isinstance(raw_items, dict) else {}
             )
-            if not items_schema:
-                # handle anyOf -> 'items': { 'anyOf': [{'type': 'integer'}, {'type': 'string'}]}
-                array_any_of = value.get('anyOf')
-                if isinstance(array_any_of, list):
-                    for option in array_any_of:
-                        if isinstance(option, dict):
-                            items_schema = first_schema_option(option)
-                            if items_schema:
-                                break
             item_type = get_make_type(items_schema.get('type'))
             item_spec: dict[str, Any] = {
                 'name': '',

--- a/server/utils/api_definitions.py
+++ b/server/utils/api_definitions.py
@@ -96,9 +96,9 @@ def openapi_to_make_schema(openapi_schema: dict[str, Any]) -> List[MakeResponseS
                     'type': 'array',
                     'label': key,
                     'spec': {
-                        # Does not require name
+                        'name': '',
                         'type': get_make_type(item.get('type', 'string')),
-                        'label': item.get('label'),
+                        'label': item.get('label', ''),
                     },
                 }
             )

--- a/server/utils/api_definitions_test.py
+++ b/server/utils/api_definitions_test.py
@@ -169,10 +169,6 @@ def test_openapi_to_make_schema():
             'integer': {'type': 'integer'},
             'boolean': {'type': 'boolean'},
             'array': {'type': 'array', 'items': {'type': 'integer'}},
-            'array_any_of': {
-                'type': 'array',
-                'anyOf': [{'type': 'integer'}, {'type': 'string'}],
-            },
             'object': {
                 'type': 'object',
                 'properties': {'id': {'type': 'integer'}, 'name': {'type': 'string'}},
@@ -183,7 +179,7 @@ def test_openapi_to_make_schema():
     make_schema = openapi_to_make_schema(openapi_schema)
     schema_list = cast(list[dict], make_schema)
     print(schema_list)
-    assert len(schema_list) == 6
+    assert len(schema_list) == 5
     assert schema_list[0].get('name') == 'integer'
     assert schema_list[0].get('type') == 'number'
     assert schema_list[1].get('name') == 'boolean'
@@ -194,16 +190,10 @@ def test_openapi_to_make_schema():
     assert 'spec' in schema_list[2]
     assert schema_list[2].get('spec', {}).get('type') == 'number'
 
-    # Check array_any_of mapping (uses first anyOf item -> integer -> number)
-    assert schema_list[3].get('name') == 'array_any_of'
-    assert schema_list[3].get('type') == 'array'
-    assert 'spec' in schema_list[3]
-    assert schema_list[3].get('spec', {}).get('type') == 'number'
-
     # Object should map to collection with nested spec
-    assert schema_list[4].get('name') == 'object'
-    assert schema_list[4].get('type') == 'collection'
-    nested_spec = schema_list[4].get('spec')
+    assert schema_list[3].get('name') == 'object'
+    assert schema_list[3].get('type') == 'collection'
+    nested_spec = schema_list[3].get('spec')
     assert isinstance(nested_spec, list)
     assert len(nested_spec) == 2
     assert nested_spec[0].get('name') == 'id'
@@ -211,5 +201,64 @@ def test_openapi_to_make_schema():
     assert nested_spec[1].get('name') == 'name'
     assert nested_spec[1].get('type') == 'text'
 
-    assert schema_list[5].get('name') == 'text_fallback'
-    assert schema_list[5].get('type') == 'text'
+    assert schema_list[4].get('name') == 'text_fallback'
+    assert schema_list[4].get('type') == 'text'
+
+
+def test_openapi_to_make_schema_items_anyof_under_items():
+    """Arrays with items.anyOf should map item spec type from the first anyOf item."""
+    openapi_schema = {
+        'type': 'object',
+        'properties': {
+            'array_items_any_of': {
+                'type': 'array',
+                'items': {
+                    'anyOf': [
+                        {'type': 'integer'},
+                        {'type': 'string'},
+                    ]
+                },
+            }
+        },
+    }
+    make_schema = openapi_to_make_schema(openapi_schema)
+    schema_list = cast(list[dict], make_schema)
+    entry = next(
+        item for item in schema_list if item.get('name') == 'array_items_any_of'
+    )
+    assert entry.get('type') == 'array'
+    # Expect first anyOf item (integer) -> number
+    assert entry.get('spec', {}).get('type') == 'number'
+
+
+def test_openapi_to_make_schema_array_of_objects_includes_nested_spec():
+    """Arrays of objects should use collection item type with nested spec retained."""
+    openapi_schema = {
+        'type': 'object',
+        'properties': {
+            'array_of_objects': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {'type': 'integer'},
+                        'name': {'type': 'string'},
+                    },
+                },
+            }
+        },
+    }
+    make_schema = openapi_to_make_schema(openapi_schema)
+    schema_list = cast(list[dict], make_schema)
+    entry = next(item for item in schema_list if item.get('name') == 'array_of_objects')
+    assert entry.get('type') == 'array'
+    # Item spec should be a collection with nested spec list
+    item_spec = entry.get('spec')
+    assert isinstance(item_spec, dict)
+    assert item_spec.get('type') == 'collection'
+    nested_spec = item_spec.get('spec')
+    assert isinstance(nested_spec, list)
+    # Validate nested fields
+    nested_by_name = {f.get('name'): f for f in nested_spec}
+    assert nested_by_name.get('id', {}).get('type') == 'number'
+    assert nested_by_name.get('name', {}).get('type') == 'text'

--- a/server/utils/api_definitions_test.py
+++ b/server/utils/api_definitions_test.py
@@ -193,14 +193,12 @@ def test_openapi_to_make_schema():
     # Check spec for array (items: integer -> number)
     assert 'spec' in schema_list[2]
     assert schema_list[2].get('spec', {}).get('type') == 'number'
-    assert schema_list[2].get('spec', {}).get('label') is None
 
     # Check array_any_of mapping (uses first anyOf item -> integer -> number)
     assert schema_list[3].get('name') == 'array_any_of'
     assert schema_list[3].get('type') == 'array'
     assert 'spec' in schema_list[3]
     assert schema_list[3].get('spec', {}).get('type') == 'number'
-    assert schema_list[3].get('spec', {}).get('label') is None
 
     # Object should map to collection with nested spec
     assert schema_list[4].get('name') == 'object'


### PR DESCRIPTION
Make uses a schema that isn’t OpenAPI-compatible. 
Built an endpoint to convert our OpenAPI schema into a Make-compatible format, since doing the conversion inside Make would be a headache given its very limited JS functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /api/definitions/{api_name}/make_schema to return a Make.com-compatible schema for the selected API, simplifying downstream integrations.

- Tests
  - Added comprehensive tests for OpenAPI-to-Make schema conversion, covering primitives, arrays (including anyOf), nested objects, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->