### PR TITLE
Fix/container health

### DIFF
--- a/server/models/base.py
+++ b/server/models/base.py
@@ -210,6 +210,7 @@ class Session(BaseModel):
     is_archived: bool = False
     archive_reason: Optional[str] = None
     last_job_time: Optional[datetime] = None
+    container_status: Optional[Dict[str, Any]] = None
 
 
 class SessionCreate(BaseModel):

--- a/server/settings.py
+++ b/server/settings.py
@@ -78,6 +78,9 @@ class Settings(BaseSettings):
     DATABASE_POOL_RECYCLE: int = 3600
     DATABASE_POOL_PRE_PING: bool = True
 
+    # Maintenance leader retry interval
+    MAINTENANCE_LEADER_RETRY_INTERVAL: int = 120  # 2 minutes
+
     API_KEY_NAME: str = 'X-API-Key'
 
     # Maximum number of tokens (input + output) allowed per job

--- a/server/utils/session_monitor.py
+++ b/server/utils/session_monitor.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 # How often to check session states (in seconds)
 INIT_CHECK_INTERVAL = 5  # Check every second during initialization
-READY_CHECK_INTERVAL = 60  # Check every 60 seconds once ready
+READY_CHECK_INTERVAL = 30  # Check every 30 seconds once ready
 INACTIVE_SESSION_THRESHOLD = 60 * 60  # 60 minutes in seconds
 
 


### PR DESCRIPTION
- Add `container_status` to the Session type, ensuring it remains available in GET /sessions responses.  
- Introduce loop to enforce a maintenance lock, (hopefully) fixing the current issue where maintenance checks are no longer running.  
  - If this is identified as the core issue, add a liveness check for the current leader.  
