### PR TITLE
fix(frontend): avoid race on first-load AI provider status (wait for API key)

### DIFF
--- a/app/contexts/AiProviderContext.tsx
+++ b/app/contexts/AiProviderContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ProviderConfiguration } from '@/gen/endpoints';
 import { getProviders } from '../services/apiService';
+import { useApiKey } from './ApiKeyContext';
 
 // Create the context
 export const AiProviderContext = createContext({
@@ -18,7 +19,8 @@ export const AiProvider = ({ children }) => {
   const [currentProvider, setCurrentProvider] = useState<string | null>(null);
   const [hasConfiguredProvider, setHasConfiguredProvider] = useState<boolean>(false);
   const [isProviderValid, setIsProviderValid] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
+  const { apiKey } = useApiKey();
 
   // Function to refresh provider data
   const refreshProviders = async () => {
@@ -48,10 +50,12 @@ export const AiProvider = ({ children }) => {
     }
   };
 
-  // Initial load of providers
+  // Load providers whenever an API key becomes available/changes
   useEffect(() => {
-    refreshProviders();
-  }, []);
+    if (apiKey) {
+      refreshProviders();
+    }
+  }, [apiKey]);
 
   // Context value
   const value = {


### PR DESCRIPTION
This PR fixes a race condition where the AI provider status fetch could run before a newly supplied API key was applied, causing the initial load to fail.\n\nChanges:\n- AiProviderContext now reads from ApiKeyContext and triggers refresh when an API key is available/changes.\n- Initial loading is set to false to avoid indefinite spinner when no key is present yet.\n\nValidation:\n- pnpm install --frozen-lockfile (no changes)\n- pnpm run typecheck (OK)\n- pnpm run build (OK)\n- Biome check reports warnings unrelated to this change (no new issues introduced).\n\nDroid-assisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Providers now load automatically after you add an API key.

- Bug Fixes
  - Prevents provider loading before an API key is set, reducing errors and unnecessary requests.
  - Loading indicator now accurately reflects the fetch lifecycle for provider data, improving perceived responsiveness.
  - Smoother first-run flow: no premature loading attempts without credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->