### PR TITLE
fix: change int openapi type from 'integer' to 'number' for improved …

### DIFF
--- a/server/utils/api_definitions.py
+++ b/server/utils/api_definitions.py
@@ -46,7 +46,8 @@ def infer_schema_from_response_example(response_example: Any) -> Dict[str, Any]:
         if isinstance(value, bool):
             return {'type': 'boolean'}
         if isinstance(value, int):
-            return {'type': 'integer'}
+            # Treating integers as numbers to ease validation strictness
+            return {'type': 'number'}
         if isinstance(value, float):
             return {'type': 'number'}
         if isinstance(value, str):

--- a/server/utils/api_definitions_test.py
+++ b/server/utils/api_definitions_test.py
@@ -17,7 +17,7 @@ def test_infer_schema_types():
     }
     schema = infer_schema_from_response_example(example)
     assert schema.get('type') == 'object'
-    assert schema.get('properties', {}).get('id').get('type') == 'integer'
+    assert schema.get('properties', {}).get('id').get('type') == 'number'
     assert schema.get('properties', {}).get('name').get('type') == 'string'
     assert schema.get('properties', {}).get('active').get('type') == 'boolean'
     assert schema.get('properties', {}).get('items').get('type') == 'array'
@@ -38,7 +38,7 @@ def test_infer_schema_nested_objects():
     }
     schema = infer_schema_from_response_example(example)
     assert schema.get('type') == 'object'
-    assert schema.get('properties', {}).get('shallow_value').get('type') == 'integer'
+    assert schema.get('properties', {}).get('shallow_value').get('type') == 'number'
     assert schema.get('properties', {}).get('nested_value').get('type') == 'object'
     assert (
         schema.get('properties', {})
@@ -46,7 +46,7 @@ def test_infer_schema_nested_objects():
         .get('properties', {})
         .get('id')
         .get('type')
-        == 'integer'
+        == 'number'
     )
     assert (
         schema.get('properties', {})
@@ -95,7 +95,7 @@ def test_infer_schema_from_response_example_duplicate_array_items():
     homogeneous_items = (
         schema.get('properties', {}).get('homogeneous_array', {}).get('items', {})
     )
-    assert homogeneous_items.get('type') == 'integer'
+    assert homogeneous_items.get('type') == 'number'
 
     # Heterogeneous array should use anyOf
     heterogeneous_items = (
@@ -154,24 +154,24 @@ def test_infer_schema_from_response_example_nested_objects_in_arrays():
     obj2_properties = object_schemas[1].get('properties', {})
 
     # First object should have 'id' and 'name'
-    assert obj1_properties.get('id', {}).get('type') == 'integer'
+    assert obj1_properties.get('id', {}).get('type') == 'number'
     assert obj1_properties.get('name', {}).get('type') == 'string'
 
     # Second object should have 'id' and 'number'
-    assert obj2_properties.get('id', {}).get('type') == 'integer'
-    assert obj2_properties.get('number', {}).get('type') == 'integer'
+    assert obj2_properties.get('id', {}).get('type') == 'number'
+    assert obj2_properties.get('number', {}).get('type') == 'number'
 
 
 def test_openapi_to_make_schema():
     openapi_schema = {
         'type': 'object',
         'properties': {
-            'integer': {'type': 'integer'},
+            'integer': {'type': 'number'},
             'boolean': {'type': 'boolean'},
-            'array': {'type': 'array', 'items': {'type': 'integer'}},
+            'array': {'type': 'array', 'items': {'type': 'number'}},
             'object': {
                 'type': 'object',
-                'properties': {'id': {'type': 'integer'}, 'name': {'type': 'string'}},
+                'properties': {'id': {'type': 'number'}, 'name': {'type': 'string'}},
             },
             'text_fallback': {'type': 'notAType'},
         },
@@ -214,7 +214,7 @@ def test_openapi_to_make_schema_items_anyof_under_items():
                 'type': 'array',
                 'items': {
                     'anyOf': [
-                        {'type': 'integer'},
+                        {'type': 'number'},
                         {'type': 'string'},
                     ]
                 },
@@ -241,7 +241,7 @@ def test_openapi_to_make_schema_array_of_objects_includes_nested_spec():
                 'items': {
                     'type': 'object',
                     'properties': {
-                        'id': {'type': 'integer'},
+                        'id': {'type': 'number'},
                         'name': {'type': 'string'},
                     },
                 },

--- a/server/utils/api_definitions_test.py
+++ b/server/utils/api_definitions_test.py
@@ -103,7 +103,7 @@ def test_infer_schema_from_response_example_duplicate_array_items():
     )
     assert 'anyOf' in heterogeneous_items
     any_of_types = [item.get('type') for item in heterogeneous_items.get('anyOf', [])]
-    assert 'integer' in any_of_types
+    assert 'number' in any_of_types
     assert 'string' in any_of_types
     assert 'boolean' in any_of_types
 
@@ -113,10 +113,10 @@ def test_infer_schema_from_response_example_duplicate_array_items():
     )
     assert 'anyOf' in duplicate_items
     any_of_schemas = duplicate_items.get('anyOf', [])
-    # Should only have 2 unique schemas: integer and string
+    # Should only have 2 unique schemas: number and string
     assert len(any_of_schemas) == 2
     any_of_types = [item.get('type') for item in any_of_schemas]
-    assert 'integer' in any_of_types
+    assert 'number' in any_of_types
     assert 'string' in any_of_types
 
 

--- a/server/utils/specs.py
+++ b/server/utils/specs.py
@@ -114,7 +114,8 @@ def convert_api_definition_to_openapi_path(
                 if isinstance(value, str):
                     response_properties[key] = {'type': 'string'}
                 elif isinstance(value, int):
-                    response_properties[key] = {'type': 'integer'}
+                    # Treating integers as numbers to ease validation strictness
+                    response_properties[key] = {'type': 'number'}
                 elif isinstance(value, float):
                     response_properties[key] = {'type': 'number'}
                 elif isinstance(value, bool):

--- a/server/utils/specs.py
+++ b/server/utils/specs.py
@@ -114,8 +114,7 @@ def convert_api_definition_to_openapi_path(
                 if isinstance(value, str):
                     response_properties[key] = {'type': 'string'}
                 elif isinstance(value, int):
-                    # Treating integers as numbers to ease validation strictness
-                    response_properties[key] = {'type': 'number'}
+                    response_properties[key] = {'type': 'integer'}
                 elif isinstance(value, float):
                     response_properties[key] = {'type': 'number'}
                 elif isinstance(value, bool):


### PR DESCRIPTION
…validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted API schema generation so integer values in response examples are represented as numeric types in the OpenAPI output, improving consistency across documented responses.
* **Documentation**
  * Generated API documentation now reflects numeric integers as numbers in response schemas for clearer, more uniform representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->