### PR TITLE
Set UV_PYTHON environment variable to 3.12 in Dockerfile

### DIFF
--- a/infra/docker/legacy-use-backend/Dockerfile
+++ b/infra/docker/legacy-use-backend/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV USERNAME=legacy-use-mgmt
 ENV HOME=/home/$USERNAME
+ENV UV_PYTHON=3.12
 
 # Install all system dependencies and create user in one layer
 RUN apt-get update && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend container environment to use Python 3.12, standardizing the runtime across services.
  * Improves compatibility with dependencies and reduces build inconsistencies for more reliable deployments.
  * No user-facing functionality changes; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->